### PR TITLE
Add policyhead search with shared temperature helpers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -161,6 +161,7 @@ common_files += [
   'src/neural/register.cc',
   'src/neural/shared_params.cc',
   'src/neural/wrapper.cc',
+  'src/search/common/temperature.cc',
   'src/search/classic/node.cc',
   'src/syzygy/syzygy.cc',
   'src/trainingdata/reader.cc',
@@ -225,6 +226,7 @@ files += [
 
 files += [
   'src/search/instamove/instamove.cc',
+  'src/search/policyhead/policyhead.cc',
 ]
 
 includes += include_directories('src')
@@ -899,6 +901,11 @@ if get_option('gtest')
     executable('syzygy_test', 'src/syzygy/syzygy_test.cc',
     include_directories: includes, link_with: lc0_lib, dependencies: gtest
   ), args: '--gtest_output=xml:syzygy.xml', timeout: 90)
+
+  test('TemperatureTest',
+    executable('temperature_test', 'src/search/common/temperature_test.cc',
+    include_directories: includes, link_with: lc0_lib, dependencies: gtest
+  ), args: '--gtest_output=xml:temperature.xml', timeout: 90)
 
   test('EncodePositionForNN',
     executable('encoder_test', 'src/neural/encoder_test.cc', pb_files,

--- a/src/search/common/temperature.cc
+++ b/src/search/common/temperature.cc
@@ -1,0 +1,71 @@
+#include "search/common/temperature.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "utils/random.h"
+
+namespace lczero {
+
+double EffectiveTau(const TempParams& p, int fullmove_number) {
+  double tau = p.temperature;
+  if (p.temp_cutoff_move > 0 && fullmove_number >= p.temp_cutoff_move) {
+    tau = p.temp_endgame;
+  } else if (p.temp_decay_moves > 0 && tau > 0) {
+    int moves_played = fullmove_number - 1;
+    if (moves_played >= p.temp_decay_moves) {
+      tau = 0.0;
+    } else {
+      tau *= static_cast<double>(p.temp_decay_moves - moves_played) /
+             static_cast<double>(p.temp_decay_moves);
+    }
+  }
+  if (tau < 0.0) tau = 0.0;
+  return tau;
+}
+
+int SampleWithTemperature(std::span<const double> base_weights,
+                          std::span<const double> winprob,
+                          const TempParams& p,
+                          double tau,
+                          Random& rng,
+                          int fallback_index) {
+  const size_t n = base_weights.size();
+  std::vector<double> weights(n);
+  double max_winprob = -std::numeric_limits<double>::infinity();
+  if (!winprob.empty()) {
+    for (double w : winprob) {
+      if (w > max_winprob) max_winprob = w;
+    }
+  }
+  double sum = 0.0;
+  const double inv_tau = tau > 0 ? 1.0 / tau : 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    double w = base_weights[i];
+    if (!winprob.empty() && max_winprob - winprob[i] > p.value_cutoff) {
+      w = 0.0;
+    }
+    if (p.visit_offset != 0.0) {
+      w = std::max(w - p.visit_offset, 0.0);
+    }
+    if (w > 0.0 && tau > 0.0) {
+      w = std::pow(w, inv_tau);
+    } else {
+      w = 0.0;
+    }
+    weights[i] = w;
+    sum += w;
+  }
+  if (sum <= 0.0) return fallback_index;
+  double toss = rng.GetDouble(sum);
+  double cumulative = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    cumulative += weights[i];
+    if (toss < cumulative) return static_cast<int>(i);
+  }
+  return fallback_index;
+}
+
+}  // namespace lczero
+

--- a/src/search/common/temperature.h
+++ b/src/search/common/temperature.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <span>
+#include <vector>
+
+namespace lczero {
+
+struct TempParams {
+  double temperature;
+  int temp_decay_moves;
+  int temp_cutoff_move;
+  double temp_endgame;
+  double value_cutoff;
+  double visit_offset;
+};
+
+// Returns effective temperature tau for the given fullmove number (1-based).
+// Applies cutoff and linear decay. Result is clamped to [0, +inf).
+double EffectiveTau(const TempParams& p, int fullmove_number);
+
+class Random;  // Forward declaration from utils/random.h.
+
+// Samples an index from base_weights using temperature tau. Applies value
+// cutoff and visit offset. winprob may be empty to skip value cutoff.
+// Returns fallback_index if all weights are filtered to zero.
+int SampleWithTemperature(std::span<const double> base_weights,
+                          std::span<const double> winprob,
+                          const TempParams& p,
+                          double tau,
+                          Random& rng,
+                          int fallback_index);
+
+}  // namespace lczero
+

--- a/src/search/common/temperature_test.cc
+++ b/src/search/common/temperature_test.cc
@@ -1,0 +1,59 @@
+#include "search/common/temperature.h"
+
+#include <gtest/gtest.h>
+
+#include "utils/random.h"
+
+namespace lczero {
+
+TEST(TemperatureTest, EffectiveTauDecayAndCutoff) {
+  TempParams p{1.0, 10, 0, 0.0, 0.0, 0.0};
+  EXPECT_DOUBLE_EQ(EffectiveTau(p, 1), 1.0);
+  EXPECT_NEAR(EffectiveTau(p, 5), 0.6, 1e-9);
+  EXPECT_DOUBLE_EQ(EffectiveTau(p, 11), 0.0);
+  p.temp_cutoff_move = 5;
+  p.temp_endgame = 0.3;
+  EXPECT_DOUBLE_EQ(EffectiveTau(p, 5), 0.3);
+}
+
+TEST(TemperatureTest, SampleProbabilityShift) {
+  TempParams p{0.0, 0, 0, 0.0, 0.0, 0.0};
+  std::vector<double> base{1.0, 4.0};
+  std::vector<double> wp{0.5, 0.5};
+  int count = 0;
+  for (int i = 0; i < 5000; ++i) {
+    int idx = SampleWithTemperature(base, wp, p, 1.0, Random::Get(), 0);
+    if (idx == 1) ++count;
+  }
+  double freq = static_cast<double>(count) / 5000.0;
+  EXPECT_NEAR(freq, 4.0 / 5.0, 0.05);
+
+  count = 0;
+  for (int i = 0; i < 5000; ++i) {
+    int idx = SampleWithTemperature(base, wp, p, 0.5, Random::Get(), 0);
+    if (idx == 1) ++count;
+  }
+  freq = static_cast<double>(count) / 5000.0;
+  EXPECT_NEAR(freq, 16.0 / 17.0, 0.05);
+}
+
+TEST(TemperatureTest, CutoffAndVisitOffset) {
+  TempParams p{0.0, 0, 0, 0.0, 0.1, 0.0};
+  std::vector<double> base{1.0, 1.0};
+  std::vector<double> wp{1.0, 0.8};
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(0, SampleWithTemperature(base, wp, p, 1.0, Random::Get(), 0));
+  }
+  p.visit_offset = 2.0;
+  std::vector<double> base2{1.0};
+  EXPECT_EQ(0, SampleWithTemperature(base2, std::span<const double>(), p, 1.0,
+                                     Random::Get(), 0));
+}
+
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/src/search/policyhead/policyhead.cc
+++ b/src/search/policyhead/policyhead.cc
@@ -1,0 +1,166 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2024 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+
+  Additional permission under GNU GPL version 3 section 7
+
+  If you modify this Program, or any covered work, by linking or
+  combining it with NVIDIA Corporation's libraries from the NVIDIA CUDA
+  Toolkit and the NVIDIA CUDA Deep Neural Network library (or a
+  modified version of those libraries), containing parts covered by the
+  terms of the respective license agreement, the licensors of this
+  Program grant you additional permission to convey the resulting work.
+*/
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include "chess/gamestate.h"
+#include "chess/uciloop.h"
+#include "neural/backend.h"
+#include "neural/batchsplit.h"
+#include "search/classic/params.h"
+#include "search/common/temperature.h"
+#include "search/register.h"
+#include "search/search.h"
+#include "utils/random.h"
+
+namespace lczero {
+namespace {
+
+class InstamoveSearch : public SearchBase {
+ public:
+  using SearchBase::SearchBase;
+
+ private:
+  virtual Move GetBestMove(const GameState& game_state) = 0;
+
+  void SetPosition(const GameState& game_state) final { game_state_ = game_state; }
+
+  void StartSearch(const GoParams& go_params) final {
+    responded_bestmove_.store(false, std::memory_order_relaxed);
+    bestmove_ = GetBestMove(game_state_);
+    if (!go_params.infinite && !go_params.ponder) RespondBestMove();
+  }
+
+  void WaitSearch() final {
+    while (!responded_bestmove_.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  void StopSearch() final { RespondBestMove(); }
+  void AbortSearch() final { responded_bestmove_.store(true); }
+
+  void RespondBestMove() {
+    if (responded_bestmove_.exchange(true)) return;
+    BestMoveInfo info{bestmove_};
+    if (game_state_.CurrentPosition().IsBlackToMove()) {
+      info.bestmove.Flip();
+    } else if (!info.ponder.is_null()) {
+      info.ponder.Flip();
+    }
+    uci_responder_->OutputBestMove(&info);
+  }
+
+  void SetBackend(Backend* backend) override {
+    batchsplit_backend_ = CreateBatchSplitingBackend(backend);
+    backend_ = batchsplit_backend_.get();
+  }
+
+  void StartClock() final {}
+
+  Move bestmove_;
+  std::atomic<bool> responded_bestmove_{false};
+  std::unique_ptr<Backend> batchsplit_backend_;
+  GameState game_state_;
+};
+
+class PolicyHeadTempSearch : public InstamoveSearch {
+ public:
+  PolicyHeadTempSearch(UciResponder* responder, TempParams params)
+      : InstamoveSearch(responder), params_(params) {}
+
+ private:
+  Move GetBestMove(const GameState& game_state) final {
+    const std::vector<Position> positions = game_state.GetPositions();
+    MoveList legal_moves = positions.back().GetBoard().GenerateLegalMoves();
+    std::vector<EvalResult> res = backend_->EvaluateBatch(
+        std::vector<EvalPosition>{EvalPosition{positions, legal_moves}});
+    const size_t best_move_idx =
+        std::max_element(res[0].p.begin(), res[0].p.end()) - res[0].p.begin();
+
+    std::vector<ThinkingInfo> infos = {{
+        .depth = 1,
+        .seldepth = 1,
+        .nodes = 1,
+        .score = 90 * std::tan(1.5637541897 * res[0].q),
+        .wdl = ThinkingInfo::WDL{
+            static_cast<int>(std::round(500 * (1 + res[0].q - res[0].d))),
+            static_cast<int>(std::round(1000 * res[0].d)),
+            static_cast<int>(std::round(500 * (1 - res[0].q - res[0].d)))}},
+    }};
+    uci_responder_->OutputThinkingInfo(&infos);
+
+    Move best_move;
+    const int fullmove = positions.back().GetGamePly() / 2 + 1;
+    const double tau = EffectiveTau(params_, fullmove);
+    if (tau > 0.0 && legal_moves.size() > 1) {
+      std::vector<double> policy(res[0].p.begin(), res[0].p.end());
+      TempParams p = params_;
+      p.visit_offset = 0.0;
+      int idx = SampleWithTemperature(policy, std::span<const double>(), p, tau,
+                                      Random::Get(),
+                                      static_cast<int>(best_move_idx));
+      best_move = legal_moves[idx];
+    } else {
+      best_move = legal_moves[best_move_idx];
+    }
+    return best_move;
+  }
+
+  TempParams params_;
+};
+
+class PolicyHeadTempFactory : public SearchFactory {
+  std::string_view GetName() const override { return "policyhead_temp"; }
+  void PopulateParams(OptionsParser* parser) const override {
+    classic::BaseSearchParams::Populate(parser);
+  }
+  std::unique_ptr<SearchBase> CreateSearch(UciResponder* responder,
+                                           const OptionsDict* options) const override {
+    classic::BaseSearchParams base_params(*options);
+    TempParams params{
+        .temperature = base_params.GetTemperature(),
+        .temp_decay_moves = base_params.GetTempDecayMoves(),
+        .temp_cutoff_move = base_params.GetTemperatureCutoffMove(),
+        .temp_endgame = base_params.GetTemperatureEndgame(),
+        .value_cutoff = base_params.GetTemperatureWinpctCutoff(),
+        .visit_offset = base_params.GetTemperatureVisitOffset(),
+    };
+    return std::make_unique<PolicyHeadTempSearch>(responder, params);
+  }
+};
+
+REGISTER_SEARCH(PolicyHeadTempFactory)
+
+}  // namespace
+}  // namespace lczero
+


### PR DESCRIPTION
## Summary
- add temperature utilities for decay, cutoff, and sampling logic
- introduce experimental `policyhead_temp` search using decaying temperature on policy probabilities
- wire temperature test to build system

## Testing
- `ninja -C build temperature_test`
- `./build/temperature_test`


------
https://chatgpt.com/codex/tasks/task_e_68afb55aadfc8331b857068abeba7a6b